### PR TITLE
Fix native build

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,24 +1,24 @@
 {:tasks
- {:init (def libsci (str (first (fs/glob "clj" "LibScimacs.{dylib,dll,solib}"))))
-  :requires ([babashka.fs :as fs])
+ {:requires ([babashka.fs :as fs])
+  :init (do (def libsci (str (first (fs/glob "clj" "LibScimacs.{dylib,dll,solib}"))))
+            (def uberjar "clj/target/uber.jar"))
   javac {:doc "Build libscimacs's JVM bytecode"
-         :task (when (seq (fs/modified-since "clj/target/classes" ["clj/src" "clj/build.clj" "clj/deps.edn"]))
+         :task (when (seq (fs/modified-since uberjar ["clj/src" "clj/build.clj" "clj/deps.edn"]))
                  (clojure
                   {:dir "clj"} "-T:build libscimacs"))}
   native-image {:doc "Build native-image"
                 :depends [javac]
-                :task (when (seq (fs/modified-since libsci ["clj/target/classes"]))
+                :task (when (seq (fs/modified-since libsci uberjar))
                         (shell
                          {:dir "clj"}
                          "native-image"
+                         "-cp" "target/uber.jar"
                          "--shared"
-                         "-cp" "target/classes"
                          "-H:Name=LibScimacs"
                          "--enable-preview"
                          "-H:+ReportExceptionStackTraces"
                          "-J-Dclojure.spec.skip-macros=true"
                          "-J-Dclojure.compiler.direct-linking=true"
-                         "--initialize-at-build-time"
                          "--verbose"
                          "--no-fallback"
                          "--no-server"

--- a/clj/build.clj
+++ b/clj/build.clj
@@ -4,19 +4,28 @@
 (def lib 'com.rusher/scimacs)
 (def version (format "0.1.%s" (b/git-count-revs nil)))
 (def class-dir "target/classes")
-(def basis (b/create-basis {:project "deps.edn"}))
+(def uber-file "target/uber.jar")
+(def basis (b/create-basis {:project "deps.edn" :aliases [:native :native-22.3.1]}))
 
 (defn clean [_]
   (b/delete {:path "target"}))
 
 (defn libscimacs [_]
   (clean nil)
+  (println "Compiling clojure...")
   (b/compile-clj {:basis basis
                   :src-dirs ["src"]
                   :class-dir class-dir
                   :jvm-opts ["-Dclojure.compiler.direct-linking=true"
-                             "-Dclojure.spec.skip-macros=true"]})
+                             "-Dclojure.spec.skip-macros=true"]
+                  :ns-compile '[com.rusher.scimacs]})
 
+  (println "Compiling java...")
   (b/javac {:src-dirs ["src"]
             :class-dir class-dir
-            :basis basis}))
+            :basis basis})
+
+  (println "Creating uberjar:" uber-file)
+  (b/uber {:class-dir class-dir
+           :uber-file uber-file
+           :basis basis}))

--- a/clj/deps.edn
+++ b/clj/deps.edn
@@ -1,8 +1,9 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        org.babashka/sci {:mvn/version "0.7.39"}
-        org.graalvm.nativeimage/svm {:mvn/version "22.3.1"}}
- :aliases {;; Run with clj -T:build
+        org.babashka/sci {:mvn/version "0.7.39"}}
+ :aliases {:native {:extra-deps {com.github.clj-easy/graal-build-time {:mvn/version "0.1.4"}}}
+           :native-22.3.1 {:extra-deps {org.graalvm.nativeimage/svm {:mvn/version "22.3.1"}}}
+           ;; Run with clj -T:build
            :build {:deps {io.github.clojure/tools.build {:mvn/version "0.9.4"}}
                    :jvm-opts ["-Dclojure.compiler.direct-linking=true"
                               "-Dclojure.spec.skip-macros=true"]


### PR DESCRIPTION
- Include clj-easy graal-build-time which lets us get rid of the `--initialize-build-time` flag which is deprecated
- To ease the build process I went for an uberjar, so can just pass that as a whole to `--cp`